### PR TITLE
[FIX SECURITY] Command permissions

### DIFF
--- a/core/src/main/java/me/harry0198/infoheads/core/commands/CmdExecutor.java
+++ b/core/src/main/java/me/harry0198/infoheads/core/commands/CmdExecutor.java
@@ -33,12 +33,12 @@ public abstract class CmdExecutor {
      * @return If command execution was successful or not.
      */
     public boolean execute(Command command, OnlinePlayer sender) {
-        if (sender.hasPermission(Constants.ADMIN_PERMISSION)) {
-            eventDispatcher.dispatchEvent(new SendPlayerMessageEvent(sender, getLocalizedMessageService().getMessage(BundleMessages.NO_PERMISSION)));
-            return true;
+        if (sender.hasPermission(Constants.ADMIN_PERMISSION) || sender.hasPermission(permission)) {
+            return executeCmd(command, sender);
         }
 
-        return executeCmd(command, sender);
+        eventDispatcher.dispatchEvent(new SendPlayerMessageEvent(sender, getLocalizedMessageService().getMessage(BundleMessages.NO_PERMISSION)));
+        return true;
     }
 
     /**

--- a/spigot/src/main/java/me/harry0198/infoheads/spigot/EntryPoint.java
+++ b/spigot/src/main/java/me/harry0198/infoheads/spigot/EntryPoint.java
@@ -31,15 +31,6 @@ public final class EntryPoint extends JavaPlugin {
     private Plugin infoHeadsPlugin;
     private InfoHeadService infoHeadService;
 
-    public EntryPoint() {
-        // We set level to debug here because during the initialization procedure,
-        // this flag is overridden immediately by configuration options. However, if this cannot be loaded then an error
-        // has occurred and we want to be able to see why at the debug level.
-        LoggerFactory.setLogger(new BukkitLogger(Level.DEBUG));
-
-        initialize();
-    }
-
     /**
      * Resets the stored instances of infoheads.
      */
@@ -51,6 +42,9 @@ public final class EntryPoint extends JavaPlugin {
 
     @Override
     public void onEnable() {
+        LoggerFactory.setLogger(new BukkitLogger(Level.DEBUG));
+        initialize();
+
         new Metrics(this, 4607);
         infoHeadsPlugin.onEnable();
 


### PR DESCRIPTION
This fixes a bug where OP players could not use any commands and players without permissions had access to all commands, which allows them to execute console commands and more.

Also fixes a startup error on 1.21+ caused by plugin remap